### PR TITLE
Use network byte order

### DIFF
--- a/sec-lab-bot.py
+++ b/sec-lab-bot.py
@@ -31,7 +31,7 @@ def network_trycatch(reqtype="open"):
     return decorator
 
 def timestamp():
-    return int.to_bytes(time().__trunc__(), 8, 'little')
+    return int(time()).to_bytes(8, 'big', signed=True)
 
 @network_trycatch(reqtype="open")
 def send_open_request(conn=None):


### PR DESCRIPTION
Integers transferred over the network should be in big-endian format.

Also, signing the timestamp value allows dates before 1970.  Important to keep everything synced when we send our bot to the past.
